### PR TITLE
workflows: data and extra_data availability

### DIFF
--- a/invenio_workflows/models.py
+++ b/invenio_workflows/models.py
@@ -411,11 +411,6 @@ class BibWorkflowObject(db.Model):
             name = self.get_workflow_name()
             if not name:
                 return ""
-            # TODO: this can be removed when workflow refactoring is done
-            if not hasattr(self, "data"):
-                self.data = self.get_data()
-            if not hasattr(self, "extra_data"):
-                self.extra_data = self.get_extra_data()
             workflow_definition = workflows[name]
             formatted_data = workflow_definition.formatter(
                 self,

--- a/invenio_workflows/templates/workflows/details_base.html
+++ b/invenio_workflows/templates/workflows/details_base.html
@@ -178,7 +178,7 @@
                 <h3 class="panel-title">{{ _('Error occurred') }}</h3>
               </div>
               <div class="panel-body">
-                <h5>{{ bwobject.get_extra_data()['_last_task_name'] }}</h5>
+                <h5>{{ bwobject.extra_data['_last_task_name'] }}</h5>
                 <div class="text-right">
                   <h6 id="show-more" class="text-right">
                     <a role="button" data-toggle="modal" style="cursor: pointer" data-target="#error_details_modal" class="float-right">
@@ -191,7 +191,7 @@
                     <div class="modal-content">
                       <div class="modal-header">
                         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                        <h4 class="modal-title" id="myModalLabel">{{ _('Problem with') }}: {{ bwobject.get_extra_data()['_last_task_name'] }}</h4>
+                        <h4 class="modal-title" id="myModalLabel">{{ _('Problem with') }}: {{ bwobject.extra_data['_last_task_name'] }}</h4>
                       </div>
                       <div class="modal-body">
                         <p>{{ bwobject.get_error_message()[0] }}</p>
@@ -297,9 +297,9 @@
 
 
         {%- block action_alert -%}
-          {% if 'message' in bwobject.get_extra_data() and bwobject.get_action() != None %}
+          {% if 'message' in bwobject.extra_data and bwobject.get_action() != None %}
             <div id="usermessage" class="alert alert-warning alert-dismissible">
-              {{ bwobject.get_extra_data()['_message'] }}
+              {{ bwobject.extra_data['_message'] }}
               <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
             </div>
           {% endif %}

--- a/invenio_workflows/views/holdingpen.py
+++ b/invenio_workflows/views/holdingpen.py
@@ -33,15 +33,16 @@ import json
 import os
 
 from flask import (
-    abort,
     Blueprint,
+    abort,
     flash,
     jsonify,
     render_template,
     request,
     send_from_directory,
-    session,
+    session
 )
+
 from flask_breadcrumbs import default_breadcrumb_root, register_breadcrumb
 
 from flask_login import login_required
@@ -70,6 +71,7 @@ from ..utils import (
     get_rows,
     sort_bwolist
 )
+
 
 blueprint = Blueprint('holdingpen', __name__, url_prefix="/admin/holdingpen",
                       template_folder='../templates',
@@ -117,8 +119,12 @@ def index():
     Acts as a hub for catalogers (may be removed)
     """
     # TODO: Add user filtering
-    error_state = get_holdingpen_objects([ObjectVersion.name_from_version(ObjectVersion.ERROR)])
-    halted_state = get_holdingpen_objects([ObjectVersion.name_from_version(ObjectVersion.HALTED)])
+    error_state = get_holdingpen_objects(
+        [ObjectVersion.name_from_version(ObjectVersion.ERROR)]
+    )
+    halted_state = get_holdingpen_objects(
+        [ObjectVersion.name_from_version(ObjectVersion.HALTED)]
+    )
     return dict(error_state=error_state,
                 halted_state=halted_state)
 
@@ -219,6 +225,10 @@ def details(objectid):
     from itertools import groupby
 
     bwobject = BibWorkflowObject.query.get_or_404(objectid)
+    # FIXME(jacquerie): to be removed in workflows >= 2.0
+    bwobject.data = bwobject.get_data()
+    bwobject.extra_data = bwobject.get_extra_data()
+
     previous_object, next_object = get_previous_next_objects(
         session.get("holdingpen_current_ids"),
         objectid


### PR DESCRIPTION
`get_formatted_data` makes those two attributes available in further calls, which I find a little confusing: just make those available from the start.