### PR TITLE
installation: fix invenio_base imports

### DIFF
--- a/.travis.invenio.cfg
+++ b/.travis.invenio.cfg
@@ -32,5 +32,5 @@ ASSETS_AUTO_BUILD = False
 PACKAGES = [
     'invenio_workflows',
     'invenio_upgrader',
-    'invenio.base',
+    'invenio_base',
 ]

--- a/invenio_workflows/actions/approval.py
+++ b/invenio_workflows/actions/approval.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2012, 2013, 2014 CERN.
+# Copyright (C) 2012, 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 
 """Generic Approval action."""
 
-from invenio.base.i18n import _
+from invenio_base.i18n import _
 from flask import render_template, url_for
 
 

--- a/invenio_workflows/api.py
+++ b/invenio_workflows/api.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2012, 2013, 2014 CERN.
+# Copyright (C) 2012, 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -24,8 +24,8 @@ this is the high level API you will want to use.
 """
 
 from werkzeug.utils import import_string, cached_property
-from invenio.base.globals import cfg
-from invenio.base.config import CFG_BIBWORKFLOW_WORKER
+from invenio_base.globals import cfg
+from invenio_base.config import CFG_BIBWORKFLOW_WORKER
 from .utils import BibWorkflowObjectIdContainer
 from .models import BibWorkflowObject
 from .errors import WorkflowWorkerError

--- a/invenio_workflows/bundles.py
+++ b/invenio_workflows/bundles.py
@@ -21,7 +21,7 @@
 
 from __future__ import unicode_literals
 
-from invenio.base.bundles import invenio as _i, jquery as _j
+from invenio_base.bundles import invenio as _i, jquery as _j
 from invenio.ext.assets import Bundle, CleanCSSFilter, RequireJSFilter
 
 

--- a/invenio_workflows/manage.py
+++ b/invenio_workflows/manage.py
@@ -80,7 +80,7 @@ def list(verbose=False):
 
 def main():
     """Run manager."""
-    from invenio.base.factory import create_app
+    from invenio_base.factory import create_app
     app = create_app()
     manager.app = app
     manager.run()

--- a/invenio_workflows/models.py
+++ b/invenio_workflows/models.py
@@ -28,8 +28,8 @@ import tempfile
 
 from datetime import datetime
 
-from invenio.base.globals import cfg
-from invenio.base.helpers import unicodifier
+from invenio_base.globals import cfg
+from invenio_base.helpers import unicodifier
 from invenio.ext.sqlalchemy import db
 from invenio.ext.sqlalchemy.utils import session_manager
 

--- a/invenio_workflows/utils.py
+++ b/invenio_workflows/utils.py
@@ -25,7 +25,7 @@ from operator import attrgetter
 
 from flask import current_app, jsonify, render_template
 
-from invenio.base.helpers import unicodifier
+from invenio_base.helpers import unicodifier
 from invenio.ext.cache import cache
 
 import msgpack

--- a/invenio_workflows/views/holdingpen.py
+++ b/invenio_workflows/views/holdingpen.py
@@ -49,8 +49,8 @@ from flask_login import login_required
 
 from flask_menu import register_menu
 
-from invenio.base.decorators import templated, wash_arguments
-from invenio.base.i18n import _
+from invenio_base.decorators import templated, wash_arguments
+from invenio_base.i18n import _
 from invenio.ext.principal import permission_required
 from invenio.utils.date import pretty_date
 from invenio.utils.pagination import Pagination

--- a/invenio_workflows/views/settings.py
+++ b/invenio_workflows/views/settings.py
@@ -27,8 +27,8 @@ from flask_breadcrumbs import register_breadcrumb
 from flask_login import login_required
 from flask_menu import register_menu
 
-from invenio.base.decorators import templated
-from invenio.base.i18n import _
+from invenio_base.decorators import templated
+from invenio_base.i18n import _
 
 from .holdingpen import get_holdingpen_objects
 from ..models import ObjectVersion

--- a/invenio_workflows/workers/worker_celery.py
+++ b/invenio_workflows/workers/worker_celery.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2012, 2013, 2014 CERN.
+# Copyright (C) 2012, 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -20,7 +20,7 @@
 
 from invenio.celery import celery
 from invenio.ext.sqlalchemy.utils import session_manager
-from invenio.base.helpers import with_app_context
+from invenio_base.helpers import with_app_context
 
 from invenio_workflows.worker_result import AsynchronousResultWrapper
 from invenio_workflows.errors import WorkflowWorkerError

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -22,5 +22,6 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
+-e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
 -e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader
 -e git+git://github.com/inveniosoftware/workflows.git#egg=workflows

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
     'workflow>=1.2.0,<2.0.0',
+    'invenio-base>=0.2.1',
     'invenio-upgrader>=0.1.0',
 ]
 
@@ -51,6 +52,7 @@ test_requirements = [
 
 
 class PyTest(TestCommand):
+
     """PyTest Test."""
 
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]


### PR DESCRIPTION
* FIX Adds missing `invenio_base` dependency and amends past
  upgrade recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>