### PR TITLE
global: PEP8 update

### DIFF
--- a/invenio_workflows/errors.py
+++ b/invenio_workflows/errors.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # This file is part of Invenio.
-# Copyright (C) 2013, 2014 CERN.
+# Copyright (C) 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -101,8 +101,8 @@ class WorkflowDefinitionError(Exception):
     def __str__(self):
         """String representation."""
         return "WorkflowDefinitionError(%s, workflow_name: %s, payload: %r)" % \
-               (str(self.message), self.workflow_name, repr(self.payload)
-                or "None")
+               (str(self.message), self.workflow_name, repr(self.payload) or
+                "None")
 
 
 class WorkflowWorkerError(Exception):

--- a/invenio_workflows/registry.py
+++ b/invenio_workflows/registry.py
@@ -17,6 +17,8 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
+"""Registry for workflow definitions found."""
+
 import inspect
 
 from flask_registry import RegistryError, RegistryProxy
@@ -38,7 +40,7 @@ class WorkflowsRegistry(DictModuleAutoDiscoverySubRegistry):
                 return None
 
             if hasattr(class_or_module, attr_name):
-                #key = attr_name if key is None else key
+                # key = attr_name if key is None else key
                 return getattr(class_or_module, attr_name)
             else:
                 all_ = getattr(class_or_module, '__all__', [])

--- a/pytest.ini
+++ b/pytest.ini
@@ -25,4 +25,14 @@
 [pytest]
 addopts = --pep8 --ignore=docs --cov=invenio_workflows --cov-report=term-missing
 pep8ignore =
+    __init__.py E501
+    api.py E501
+    bundles.py E501
+    engine.py E501
+    errors.py E501
+    utils.py E501
+    worker_engine.py E501
+    logic_tasks.py E501
+    workflows_tasks.py E501
+    settings.py E501
     tests/* ALL


### PR DESCRIPTION
* FIX Fixes some PEP8 issues across the codebase. (addresses #2)

* NOTE Temporarily adds PEP8 ignore of E501 in CI to be less
  disruptive to upcoming refactoring of this module.

This makes the build pass, which is important to show stability outwards.

Then we can focus on merging #8 for `v2.0.0`