### PR TITLE
workflows: addition of batch buttons

### DIFF
--- a/invenio_workflows/static/js/workflows/selection.js
+++ b/invenio_workflows/static/js/workflows/selection.js
@@ -48,7 +48,7 @@ define(
           rowSelector: "*[data-href]",
 
           // Batch Buttons
-          batchButtons: "#batch-action-buttons",
+          batchButtons: ".batch-action-buttons",
           batchButtonSelector: ".batch-button"
       });
 

--- a/invenio_workflows/templates/workflows/list_base.html
+++ b/invenio_workflows/templates/workflows/list_base.html
@@ -196,9 +196,11 @@
         </tbody>
       </table>
       {% endblock %}
-      {% block pagination %}
-      <div id="pagination"></div>
+      {% block batch_action_buttons_bottom %}
       {% endblock %}
     </div>
+    {% block pagination %}
+      <div id="pagination"></div>
+    {% endblock %}
   </div>
 {% endblock %}


### PR DESCRIPTION
* BETTER: Turns the id 'batch-action-buttons' to a class
  and adds a new block allowing to use both appearances
  of the buttons (top and bottom) to the list.

Signed-off-by: Ilias Koutsakis <ilias.koutsakis@cern.ch>